### PR TITLE
FIXED: FileNotFoundError | ADDED:  Termux Support

### DIFF
--- a/bin/find-lib-in-path.py
+++ b/bin/find-lib-in-path.py
@@ -9,6 +9,8 @@ import os
 from argparse import ArgumentParser
 from glob import glob
 
+PREFIX = os.getenv('PREFIX') # Termux
+
 
 def parse_ld_conf_file(fn):
     paths = []
@@ -36,14 +38,19 @@ def get_ld_paths():
     paths = []
     if "LD_LIBRARY_PATH" in os.environ:
         paths.extend(os.environ["LD_LIBRARY_PATH"].split(":"))
-    paths.extend(parse_ld_conf_file("/etc/ld.so.conf"))
+    if os.path.exists("/etc/ld.so.conf"):
+        paths.extend(parse_ld_conf_file("/etc/ld.so.conf"))
+    else:
+        print("WARNING: file \"/etc/ld.so.conf\" not found.")
+    if PREFIX:
+        paths.extend([PREFIX, PREFIX + "/lib", PREFIX + "/usr/lib", PREFIX + "/lib64", PREFIX + "/usr/lib64"])
     paths.extend(["/lib", "/usr/lib", "/lib64", "/usr/lib64"])
     return paths
 
 
 def main():
     arg_parser = ArgumentParser()
-    arg_parser.add_argument("lib")
+    arg_parser.add_argument("lib", help="Name of the library (e.g. libncurses.so)")
     args = arg_parser.parse_args()
 
     paths = get_ld_paths()
@@ -59,4 +66,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
### Error
```terminal
FileNotFoundError [Errno 2] No such file or directory: '/etc/ld.so.conf'
```
### Termux
> Termux does not follow Filesystem Hierarchy Standard unlike majority of Linux distributions. You cannot find directories like /bin, /etc, /usr, /tmp and others at the usual locations. Thus, all programs must be patched and recompiled to meet requirements of the Termux environment otherwise they will not be able to find their configuration files or other data. 

> Most packages have shared library dependencies which are installed to $PREFIX/lib. 

[<sup>^ \_\_source\_\_</sup>](https://wiki.termux.com/wiki/Differences_from_Linux)
[<sup>Also found this</sup>](https://www.unix.com/man-page/linux/1/prefix/)
