### PR TITLE
find-lib-in-path.py: Fix include parsing

### DIFF
--- a/bin/find-lib-in-path.py
+++ b/bin/find-lib-in-path.py
@@ -22,7 +22,9 @@ def parse_ld_conf_file(fn):
         if l.startswith("include "):
             dirglob = l[len("include "):]
             if dirglob[0] != "/":
-                dirglob = "/etc/" + dirglob
+                patharray = os.path.normpath(fn).split(os.sep)
+                relpath = os.sep.join(patharray[0:len(patharray)-1])
+                dirglob = relpath + "/" + dirglob
             for sub_fn in glob(dirglob):
                 paths.extend(parse_ld_conf_file(sub_fn))
             continue

--- a/bin/find-lib-in-path.py
+++ b/bin/find-lib-in-path.py
@@ -22,9 +22,7 @@ def parse_ld_conf_file(fn):
         if l.startswith("include "):
             dirglob = l[len("include "):]
             if dirglob[0] != "/":
-                patharray = os.path.normpath(fn).split(os.sep)
-                relpath = os.sep.join(patharray[0:len(patharray)-1])
-                dirglob = relpath + "/" + dirglob
+                dirglob = os.path.dirname(os.path.normpath(fn)) + "/" + dirglob
             for sub_fn in glob(dirglob):
                 paths.extend(parse_ld_conf_file(sub_fn))
             continue

--- a/bin/find-lib-in-path.py
+++ b/bin/find-lib-in-path.py
@@ -20,7 +20,10 @@ def parse_ld_conf_file(fn):
         if l.startswith("#"):
             continue
         if l.startswith("include "):
-            for sub_fn in glob(l[len("include "):]):
+            dirglob = l[len("include "):]
+            if dirglob[0] != "/":
+                dirglob = "/etc/" + dirglob
+            for sub_fn in glob(dirglob):
                 paths.extend(parse_ld_conf_file(sub_fn))
             continue
         paths.append(l)


### PR DESCRIPTION
Thank you for these tools!

I found a bug in `find-lib-in-path.py`'s processing of include lines in /etc/ld.so.conf; namely, when the glob is not an absolute path, that path seems to be relative to /etc, not the current directory. (Gentoo uses a relative path in this fashion in the file, so that's how I was able to know.)

(In case you're wondering, I found this repo from your StackExchange answer at https://unix.stackexchange.com/a/637817 !)